### PR TITLE
Date Time Component Evaluative

### DIFF
--- a/homeassistant/components/recorder/history/legacy.py
+++ b/homeassistant/components/recorder/history/legacy.py
@@ -448,7 +448,7 @@ def _get_states_for_entities_stmt(
     # We got an include-list of entities, accelerate the query by filtering already
     # in the inner query.
     run_start_ts = process_timestamp(run_start).timestamp()
-    utc_point_in_time_ts = dt_util.utc_to_timestamp(utc_point_in_time)
+    utc_point_in_time_ts = utc_point_in_time.timestamp()
     stmt += lambda q: q.join(
         (
             most_recent_states_for_entities_by_date := (
@@ -520,7 +520,7 @@ def _get_single_entity_states_stmt(
     stmt, join_attributes = _lambda_stmt_and_join_attributes(
         no_attributes, include_last_changed=True
     )
-    utc_point_in_time_ts = dt_util.utc_to_timestamp(utc_point_in_time)
+    utc_point_in_time_ts = utc_point_in_time.timestamp()
     stmt += (
         lambda q: q.filter(
             States.last_updated_ts < utc_point_in_time_ts,

--- a/homeassistant/components/recorder/history/modern.py
+++ b/homeassistant/components/recorder/history/modern.py
@@ -251,7 +251,7 @@ def get_significant_states_with_session(
         run_start_ts := _get_run_start_ts_for_utc_point_in_time(hass, start_time)
     ):
         include_start_time_state = False
-    start_time_ts = dt_util.utc_to_timestamp(start_time)
+    start_time_ts = start_time.timestamp()
     end_time_ts = datetime_to_timestamp_or_none(end_time)
     single_metadata_id = metadata_ids[0] if len(metadata_ids) == 1 else None
     stmt = lambda_stmt(
@@ -416,7 +416,7 @@ def state_changes_during_period(
             run_start_ts := _get_run_start_ts_for_utc_point_in_time(hass, start_time)
         ):
             include_start_time_state = False
-        start_time_ts = dt_util.utc_to_timestamp(start_time)
+        start_time_ts = start_time.timestamp()
         end_time_ts = datetime_to_timestamp_or_none(end_time)
         stmt = lambda_stmt(
             lambda: _state_changed_during_period_stmt(

--- a/homeassistant/components/recorder/models/legacy.py
+++ b/homeassistant/components/recorder/models/legacy.py
@@ -46,7 +46,7 @@ class LegacyLazyState(State):
         self.state = self._row.state or ""
         self._attributes: dict[str, Any] | None = None
         self._last_updated_ts: float | None = self._row.last_updated_ts or (
-            dt_util.utc_to_timestamp(start_time) if start_time else None
+            start_time.timestamp() if start_time else None
         )
         self._last_changed_ts: float | None = (
             self._row.last_changed_ts or self._last_updated_ts
@@ -146,7 +146,7 @@ def legacy_row_to_compressed_state(
         COMPRESSED_STATE_ATTRIBUTES: decode_attributes_from_row_legacy(row, attr_cache),
     }
     if start_time:
-        comp_state[COMPRESSED_STATE_LAST_UPDATED] = dt_util.utc_to_timestamp(start_time)
+        comp_state[COMPRESSED_STATE_LAST_UPDATED] = start_time.timestamp()
     else:
         row_last_updated_ts: float = row.last_updated_ts
         comp_state[COMPRESSED_STATE_LAST_UPDATED] = row_last_updated_ts

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -13,6 +13,8 @@ import zoneinfo
 from aiozoneinfo import async_get_time_zone as _async_get_time_zone
 import ciso8601
 
+from homeassistant.helpers.deprecation import deprecated_function
+
 DATE_STR_FORMAT = "%Y-%m-%d"
 UTC = dt.UTC
 DEFAULT_TIME_ZONE: dt.tzinfo = dt.UTC
@@ -170,6 +172,7 @@ utc_from_timestamp = partial(dt.datetime.fromtimestamp, tz=UTC)
 """Return a UTC time from a timestamp."""
 
 
+@deprecated_function("datetime.timestamp", breaks_in_ha_version="2026.1")
 def utc_to_timestamp(utc_dt: dt.datetime) -> float:
     """Fast conversion of a datetime in UTC to a timestamp."""
     # Taken from

--- a/tests/common.py
+++ b/tests/common.py
@@ -491,7 +491,7 @@ _MONOTONIC_RESOLUTION = time.get_clock_info("monotonic").resolution
 def _async_fire_time_changed(
     hass: HomeAssistant, utc_datetime: datetime | None, fire_all: bool
 ) -> None:
-    timestamp = dt_util.utc_to_timestamp(utc_datetime)
+    timestamp = utc_datetime.timestamp()
     for task in list(get_scheduled_timer_handles(hass.loop)):
         if not isinstance(task, asyncio.TimerHandle):
             continue

--- a/tests/components/logbook/common.py
+++ b/tests/components/logbook/common.py
@@ -35,7 +35,7 @@ class MockRow:
         self.event_data = json.dumps(data, cls=JSONEncoder)
         self.data = data
         self.time_fired = dt_util.utcnow()
-        self.time_fired_ts = dt_util.utc_to_timestamp(self.time_fired)
+        self.time_fired_ts = self.time_fired.timestamp()
         self.context_parent_id_bin = (
             ulid_to_bytes_or_none(context.parent_id) if context else None
         )

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -330,7 +330,7 @@ def create_state_changed_event_from_old_new(
         row_id=1,
         event_type=PSEUDO_EVENT_STATE_CHANGED,
         event_data="{}",
-        time_fired_ts=dt_util.utc_to_timestamp(event_time_fired),
+        time_fired_ts=event_time_fired.timestamp(),
         context_id_bin=None,
         context_user_id_bin=None,
         context_parent_id_bin=None,

--- a/tests/components/recorder/db_schema_32.py
+++ b/tests/components/recorder/db_schema_32.py
@@ -254,7 +254,7 @@ class Events(Base):  # type: ignore[misc,valid-type]
             event_data=None,
             origin_idx=EVENT_ORIGIN_TO_IDX.get(event.origin),
             time_fired=None,
-            time_fired_ts=dt_util.utc_to_timestamp(event.time_fired),
+            time_fired_ts=event.time_fired.timestamp(),
             context_id=event.context.id,
             context_user_id=event.context.user_id,
             context_parent_id=event.context.parent_id,
@@ -429,16 +429,16 @@ class States(Base):  # type: ignore[misc,valid-type]
         # None state means the state was removed from the state machine
         if state is None:
             dbstate.state = ""
-            dbstate.last_updated_ts = dt_util.utc_to_timestamp(event.time_fired)
+            dbstate.last_updated_ts = event.time_fired.timestamp()
             dbstate.last_changed_ts = None
             return dbstate
 
         dbstate.state = state.state
-        dbstate.last_updated_ts = dt_util.utc_to_timestamp(state.last_updated)
+        dbstate.last_updated_ts = state.last_updated.timestamp()
         if state.last_updated == state.last_changed:
             dbstate.last_changed_ts = None
         else:
-            dbstate.last_changed_ts = dt_util.utc_to_timestamp(state.last_changed)
+            dbstate.last_changed_ts = state.last_changed.timestamp()
 
         return dbstate
 

--- a/tests/components/recorder/db_schema_42.py
+++ b/tests/components/recorder/db_schema_42.py
@@ -687,7 +687,7 @@ class StatisticsBase:
             created=None,
             created_ts=time.time(),
             start=None,
-            start_ts=dt_util.utc_to_timestamp(stats["start"]),
+            start_ts=stats["start"].timestamp(),
             mean=stats.get("mean"),
             min=stats.get("min"),
             max=stats.get("max"),

--- a/tests/components/recorder/db_schema_43.py
+++ b/tests/components/recorder/db_schema_43.py
@@ -697,7 +697,7 @@ class StatisticsBase:
             created=None,
             created_ts=time.time(),
             start=None,
-            start_ts=dt_util.utc_to_timestamp(stats["start"]),
+            start_ts=stats["start"].timestamp(),
             mean=stats.get("mean"),
             min=stats.get("min"),
             max=stats.get("max"),

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -543,7 +543,7 @@ async def test_purge_edge_case(
                     event_type="EVENT_TEST_PURGE",
                     event_data="{}",
                     origin="LOCAL",
-                    time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                    time_fired_ts=timestamp.timestamp(),
                 )
             )
             session.add(
@@ -551,8 +551,8 @@ async def test_purge_edge_case(
                     entity_id="test.recorder2",
                     state="purgeme",
                     attributes="{}",
-                    last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                    last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                    last_changed_ts=timestamp.timestamp(),
+                    last_updated_ts=timestamp.timestamp(),
                     event_id=1001,
                     attributes_id=1002,
                 )
@@ -614,7 +614,7 @@ async def test_purge_cutoff_date(hass: HomeAssistant, recorder_mock: Recorder) -
                     event_type="KEEP",
                     event_data="{}",
                     origin="LOCAL",
-                    time_fired_ts=dt_util.utc_to_timestamp(timestamp_keep),
+                    time_fired_ts=timestamp_keep.timestamp(),
                 )
             )
             session.add(
@@ -622,8 +622,8 @@ async def test_purge_cutoff_date(hass: HomeAssistant, recorder_mock: Recorder) -
                     entity_id="test.cutoff",
                     state="keep",
                     attributes="{}",
-                    last_changed_ts=dt_util.utc_to_timestamp(timestamp_keep),
-                    last_updated_ts=dt_util.utc_to_timestamp(timestamp_keep),
+                    last_changed_ts=timestamp_keep.timestamp(),
+                    last_updated_ts=timestamp_keep.timestamp(),
                     event_id=1000,
                     attributes_id=1000,
                 )
@@ -642,7 +642,7 @@ async def test_purge_cutoff_date(hass: HomeAssistant, recorder_mock: Recorder) -
                         event_type="PURGE",
                         event_data="{}",
                         origin="LOCAL",
-                        time_fired_ts=dt_util.utc_to_timestamp(timestamp_purge),
+                        time_fired_ts=timestamp_purge.timestamp(),
                     )
                 )
                 session.add(
@@ -650,8 +650,8 @@ async def test_purge_cutoff_date(hass: HomeAssistant, recorder_mock: Recorder) -
                         entity_id="test.cutoff",
                         state="purge",
                         attributes="{}",
-                        last_changed_ts=dt_util.utc_to_timestamp(timestamp_purge),
-                        last_updated_ts=dt_util.utc_to_timestamp(timestamp_purge),
+                        last_changed_ts=timestamp_purge.timestamp(),
+                        last_updated_ts=timestamp_purge.timestamp(),
                         event_id=1000 + row,
                         attributes_id=1000 + row,
                     )
@@ -800,8 +800,8 @@ async def test_purge_filtered_states(
                     entity_id="sensor.excluded",
                     state="purgeme",
                     attributes="{}",
-                    last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                    last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                    last_changed_ts=timestamp.timestamp(),
+                    last_updated_ts=timestamp.timestamp(),
                 )
             )
             # Add states and state_changed events that should be keeped
@@ -826,8 +826,8 @@ async def test_purge_filtered_states(
                 entity_id="sensor.linked_old_state_id",
                 state="keep",
                 attributes="{}",
-                last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                last_changed_ts=timestamp.timestamp(),
+                last_updated_ts=timestamp.timestamp(),
                 old_state_id=1,
                 state_attributes=state_attrs,
             )
@@ -836,8 +836,8 @@ async def test_purge_filtered_states(
                 entity_id="sensor.linked_old_state_id",
                 state="keep",
                 attributes="{}",
-                last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                last_changed_ts=timestamp.timestamp(),
+                last_updated_ts=timestamp.timestamp(),
                 old_state_id=2,
                 state_attributes=state_attrs,
             )
@@ -845,8 +845,8 @@ async def test_purge_filtered_states(
                 entity_id="sensor.linked_old_state_id",
                 state="keep",
                 attributes="{}",
-                last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                last_changed_ts=timestamp.timestamp(),
+                last_updated_ts=timestamp.timestamp(),
                 old_state_id=62,  # keep
                 state_attributes=state_attrs,
             )
@@ -858,7 +858,7 @@ async def test_purge_filtered_states(
                     event_type="EVENT_KEEP",
                     event_data="{}",
                     origin="LOCAL",
-                    time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                    time_fired_ts=timestamp.timestamp(),
                 )
             )
             convert_pending_states_to_meta(recorder_mock, session)
@@ -1042,8 +1042,8 @@ async def test_purge_without_state_attributes_filtered_states_to_empty(
                     entity_id="sensor.old_format",
                     state=STATE_ON,
                     attributes=json.dumps({"old": "not_using_state_attributes"}),
-                    last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                    last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                    last_changed_ts=timestamp.timestamp(),
+                    last_updated_ts=timestamp.timestamp(),
                     event_id=event_id,
                     state_attributes=None,
                 )
@@ -1054,7 +1054,7 @@ async def test_purge_without_state_attributes_filtered_states_to_empty(
                     event_type=EVENT_STATE_CHANGED,
                     event_data="{}",
                     origin="LOCAL",
-                    time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                    time_fired_ts=timestamp.timestamp(),
                 )
             )
             session.add(
@@ -1063,7 +1063,7 @@ async def test_purge_without_state_attributes_filtered_states_to_empty(
                     event_type=EVENT_THEMES_UPDATED,
                     event_data="{}",
                     origin="LOCAL",
-                    time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                    time_fired_ts=timestamp.timestamp(),
                 )
             )
             convert_pending_states_to_meta(recorder_mock, session)
@@ -1118,7 +1118,7 @@ async def test_purge_filtered_events(
                             event_type="EVENT_PURGE",
                             event_data="{}",
                             origin="LOCAL",
-                            time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                            time_fired_ts=timestamp.timestamp(),
                         )
                     )
 
@@ -1225,7 +1225,7 @@ async def test_purge_filtered_events_state_changed(
                         event_type="EVENT_KEEP",
                         event_data="{}",
                         origin="LOCAL",
-                        time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                        time_fired_ts=timestamp.timestamp(),
                     )
                 )
             # Add states with linked old_state_ids that need to be handled
@@ -1234,8 +1234,8 @@ async def test_purge_filtered_events_state_changed(
                 entity_id="sensor.linked_old_state_id",
                 state="keep",
                 attributes="{}",
-                last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                last_changed_ts=timestamp.timestamp(),
+                last_updated_ts=timestamp.timestamp(),
                 old_state_id=1,
             )
             timestamp = dt_util.utcnow() - timedelta(days=4)
@@ -1243,16 +1243,16 @@ async def test_purge_filtered_events_state_changed(
                 entity_id="sensor.linked_old_state_id",
                 state="keep",
                 attributes="{}",
-                last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                last_changed_ts=timestamp.timestamp(),
+                last_updated_ts=timestamp.timestamp(),
                 old_state_id=2,
             )
             state_3 = States(
                 entity_id="sensor.linked_old_state_id",
                 state="keep",
                 attributes="{}",
-                last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                last_changed_ts=timestamp.timestamp(),
+                last_updated_ts=timestamp.timestamp(),
                 old_state_id=62,  # keep
             )
             session.add_all((state_1, state_2, state_3))
@@ -1262,7 +1262,7 @@ async def test_purge_filtered_events_state_changed(
                     event_type="excluded_event",
                     event_data="{}",
                     origin="LOCAL",
-                    time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                    time_fired_ts=timestamp.timestamp(),
                 )
             )
             session.add(
@@ -1270,8 +1270,8 @@ async def test_purge_filtered_events_state_changed(
                     entity_id="sensor.old_format",
                     state="remove",
                     attributes="{}",
-                    last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                    last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                    last_changed_ts=timestamp.timestamp(),
+                    last_updated_ts=timestamp.timestamp(),
                 )
             )
             convert_pending_events_to_event_types(recorder_mock, session)
@@ -1637,8 +1637,8 @@ def _add_state_without_event_linkage(
             entity_id=entity_id,
             state=state,
             attributes=None,
-            last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-            last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+            last_changed_ts=timestamp.timestamp(),
+            last_updated_ts=timestamp.timestamp(),
             event_id=None,
             state_attributes=state_attrs,
         )
@@ -1662,8 +1662,8 @@ def _add_state_with_state_attributes(
             entity_id=entity_id,
             state=state,
             attributes=None,
-            last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-            last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+            last_changed_ts=timestamp.timestamp(),
+            last_updated_ts=timestamp.timestamp(),
             event_id=event_id,
             state_attributes=state_attrs,
         )
@@ -1785,7 +1785,7 @@ async def test_purge_old_events_purges_the_event_type_ids(
                         Events(
                             event_type=None,
                             event_type_id=event_type.event_type_id,
-                            time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                            time_fired_ts=timestamp.timestamp(),
                         )
                     )
             return recorder_mock.event_type_manager.get_many(
@@ -1915,7 +1915,7 @@ async def test_purge_old_states_purges_the_state_metadata_ids(
                         States(
                             metadata_id=metadata_id,
                             state="any",
-                            last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                            last_updated_ts=timestamp.timestamp(),
                         )
                     )
             return recorder_mock.states_meta_manager.get_many(

--- a/tests/components/recorder/test_purge_v32_schema.py
+++ b/tests/components/recorder/test_purge_v32_schema.py
@@ -509,7 +509,7 @@ async def test_purge_edge_case(hass: HomeAssistant, use_sqlite: bool) -> None:
                     event_type="EVENT_TEST_PURGE",
                     event_data="{}",
                     origin="LOCAL",
-                    time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                    time_fired_ts=timestamp.timestamp(),
                 )
             )
             session.add(
@@ -517,8 +517,8 @@ async def test_purge_edge_case(hass: HomeAssistant, use_sqlite: bool) -> None:
                     entity_id="test.recorder2",
                     state="purgeme",
                     attributes="{}",
-                    last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-                    last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+                    last_changed_ts=timestamp.timestamp(),
+                    last_updated_ts=timestamp.timestamp(),
                     event_id=1001,
                     attributes_id=1002,
                 )
@@ -576,7 +576,7 @@ async def test_purge_cutoff_date(hass: HomeAssistant, recorder_mock: Recorder) -
                     event_type="KEEP",
                     event_data="{}",
                     origin="LOCAL",
-                    time_fired_ts=dt_util.utc_to_timestamp(timestamp_keep),
+                    time_fired_ts=timestamp_keep.timestamp(),
                 )
             )
             session.add(
@@ -584,8 +584,8 @@ async def test_purge_cutoff_date(hass: HomeAssistant, recorder_mock: Recorder) -
                     entity_id="test.cutoff",
                     state="keep",
                     attributes="{}",
-                    last_changed_ts=dt_util.utc_to_timestamp(timestamp_keep),
-                    last_updated_ts=dt_util.utc_to_timestamp(timestamp_keep),
+                    last_changed_ts=timestamp_keep.timestamp(),
+                    last_updated_ts=timestamp_keep.timestamp(),
                     event_id=1000,
                     attributes_id=1000,
                 )
@@ -604,7 +604,7 @@ async def test_purge_cutoff_date(hass: HomeAssistant, recorder_mock: Recorder) -
                         event_type="PURGE",
                         event_data="{}",
                         origin="LOCAL",
-                        time_fired_ts=dt_util.utc_to_timestamp(timestamp_purge),
+                        time_fired_ts=timestamp_purge.timestamp(),
                     )
                 )
                 session.add(
@@ -612,8 +612,8 @@ async def test_purge_cutoff_date(hass: HomeAssistant, recorder_mock: Recorder) -
                         entity_id="test.cutoff",
                         state="purge",
                         attributes="{}",
-                        last_changed_ts=dt_util.utc_to_timestamp(timestamp_purge),
-                        last_updated_ts=dt_util.utc_to_timestamp(timestamp_purge),
+                        last_changed_ts=timestamp_purge.timestamp(),
+                        last_updated_ts=timestamp_purge.timestamp(),
                         event_id=1000 + row,
                         attributes_id=1000 + row,
                     )
@@ -771,7 +771,7 @@ async def _add_test_events(hass: HomeAssistant, iterations: int = 1):
                         event_type=event_type,
                         event_data=json.dumps(event_data),
                         origin="LOCAL",
-                        time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                        time_fired_ts=timestamp.timestamp(),
                     )
                 )
 
@@ -808,7 +808,7 @@ async def _add_events_with_event_data(hass: HomeAssistant, iterations: int = 1):
                     Events(
                         event_type=event_type,
                         origin="LOCAL",
-                        time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+                        time_fired_ts=timestamp.timestamp(),
                         event_data_rel=event_data,
                     )
                 )
@@ -910,8 +910,8 @@ def _add_state_without_event_linkage(
             entity_id=entity_id,
             state=state,
             attributes=None,
-            last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-            last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+            last_changed_ts=timestamp.timestamp(),
+            last_updated_ts=timestamp.timestamp(),
             event_id=None,
             state_attributes=state_attrs,
         )
@@ -935,8 +935,8 @@ def _add_state_and_state_changed_event(
             entity_id=entity_id,
             state=state,
             attributes=None,
-            last_changed_ts=dt_util.utc_to_timestamp(timestamp),
-            last_updated_ts=dt_util.utc_to_timestamp(timestamp),
+            last_changed_ts=timestamp.timestamp(),
+            last_updated_ts=timestamp.timestamp(),
             event_id=event_id,
             state_attributes=state_attrs,
         )
@@ -947,7 +947,7 @@ def _add_state_and_state_changed_event(
             event_type=EVENT_STATE_CHANGED,
             event_data="{}",
             origin="LOCAL",
-            time_fired_ts=dt_util.utc_to_timestamp(timestamp),
+            time_fired_ts=timestamp.timestamp(),
         )
     )
 

--- a/tests/util/test_dt.py
+++ b/tests/util/test_dt.py
@@ -116,10 +116,14 @@ def test_utc_from_timestamp() -> None:
     )
 
 
-def test_timestamp_to_utc() -> None:
+def test_timestamp_to_utc(caplog: pytest.LogCaptureFixture) -> None:
     """Test we can convert a utc datetime to a timestamp."""
     utc_now = dt_util.utcnow()
     assert dt_util.utc_to_timestamp(utc_now) == utc_now.timestamp()
+    assert (
+        "utc_to_timestamp is a deprecated function which will be removed "
+        "in HA Core 2026.1. Use datetime.timestamp instead" in caplog.text
+    )
 
 
 def test_as_timestamp() -> None:


### PR DESCRIPTION
**Mohammad Ikhwan Bin Mohd Kamarudin (U2000880)**

1. Evaluative Maintenance on Date Time Component

This PR introduces the deprecation of the utc_to_timestamp function across the codebase, aligning with Python's standard library method datetime.timestamp. The changes ensure modernized practices and prepare the integration for future maintenance by marking the custom function as deprecated.

**Changes Made**

util/dt.py
 - Marked utc_to_timestamp as deprecated using the @deprecated_function decorator:
 - Added @deprecated_function("datetime.timestamp", breaks_in_ha_version="2026.1") to inform developers about the deprecation timeline.
  - Updated the docstring to reflect its deprecation and the preferred alternative, datetime.timestamp.

Affected Files
- Replaced all occurrences of utc_to_timestamp with datetime.timestamp across the following modules:
- components/recorder/history/legacy.py
- components/recorder/history/modern.py
- components/recorder/models/legacy.py
- tests/common.py
- tests/components/logbook/common.py
- tests/components/logbook/test_init.py
- recorder/db_schema_32.py
- recorder/db_schema_42.py
- recorder/db_schema_43.py
- recorder/test_purge.py
- recorder/test_purge_v32_schema.py

Tests
- Updated the test files to ensure compatibility with the new method:
- Adjusted calls to utc_to_timestamp in the following files:
- tests/util/test_dt.py
- recorder/test_purge.py
- recorder/test_purge_v32_schema.py
- Verified the behavior remains consistent when using datetime.timestamp.

Rationale
- The datetime.timestamp method is the recommended way to convert datetime objects to timestamps in modern Python versions.
- Deprecating utc_to_timestamp reduces reliance on custom utilities, simplifying the codebase and aligning with standard practices.
- The deprecation decorator ensures a clear transition timeline, notifying developers well in advance of its removal.