### PR TITLE
Enhancive maintenance for todo component-2

### DIFF
--- a/homeassistant/components/todo/__init__.py
+++ b/homeassistant/components/todo/__init__.py
@@ -196,6 +196,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _async_remove_completed_items,
         required_features=[TodoListEntityFeature.DELETE_TODO_ITEM],
     )
+    component.async_register_entity_service(
+        TodoServices.REMOVE_ALL_ITEMS,
+        None,
+        _async_remove_all_items,
+        required_features=[TodoListEntityFeature.DELETE_TODO_ITEM],
+    )
 
     await component.async_setup(config)
     return True
@@ -563,5 +569,12 @@ async def _async_remove_completed_items(entity: TodoListEntity, _: ServiceCall) 
         for item in entity.todo_items or ()
         if item.status == TodoItemStatus.COMPLETED and item.uid
     ]
+    if uids:
+        await entity.async_delete_todo_items(uids=uids)
+
+
+async def _async_remove_all_items(entity: TodoListEntity, _: ServiceCall) -> None:
+    """Remove all items from the To-do list."""
+    uids = [item.uid for item in entity.todo_items or () if item.uid]
     if uids:
         await entity.async_delete_todo_items(uids=uids)

--- a/homeassistant/components/todo/const.py
+++ b/homeassistant/components/todo/const.py
@@ -32,6 +32,7 @@ class TodoServices(StrEnum):
     REMOVE_ITEM = "remove_item"
     GET_ITEMS = "get_items"
     REMOVE_COMPLETED_ITEMS = "remove_completed_items"
+    REMOVE_ALL_ITEMS = "remove_all_items"
 
 
 class TodoListEntityFeature(IntFlag):

--- a/homeassistant/components/todo/icons.json
+++ b/homeassistant/components/todo/icons.json
@@ -14,6 +14,9 @@
     "remove_completed_items": {
       "service": "mdi:clipboard-remove"
     },
+    "remove_all_items": {
+      "service": "mdi:clipboard-off"
+    },
     "remove_item": {
       "service": "mdi:clipboard-minus"
     },

--- a/homeassistant/components/todo/services.yaml
+++ b/homeassistant/components/todo/services.yaml
@@ -13,6 +13,7 @@ get_items:
             - needs_action
             - completed
           multiple: true
+
 add_item:
   target:
     entity:
@@ -46,6 +47,7 @@ add_item:
       example: "A more complete description of the to-do item than that provided by the summary."
       selector:
         text:
+
 update_item:
   target:
     entity:
@@ -91,6 +93,7 @@ update_item:
       example: "A more complete description of the to-do item than that provided by the summary."
       selector:
         text:
+
 remove_item:
   target:
     entity:
@@ -104,6 +107,13 @@ remove_item:
         text:
 
 remove_completed_items:
+  target:
+    entity:
+      domain: todo
+      supported_features:
+        - todo.TodoListEntityFeature.DELETE_TODO_ITEM
+
+remove_all_items:
   target:
     entity:
       domain: todo

--- a/homeassistant/components/todo/strings.json
+++ b/homeassistant/components/todo/strings.json
@@ -72,6 +72,10 @@
       "name": "Remove all completed to-do list items",
       "description": "Remove all to-do list items that have been completed."
     },
+    "remove_all_items": {
+      "name": "Remove all to-do list items",
+      "description": "Remove all to-do list items, clearing the to-do list."
+    },
     "remove_item": {
       "name": "Remove a to-do list item",
       "description": "Remove an existing to-do list item by its name.",


### PR DESCRIPTION
This PR introduces the remove_all_items action to the Todo integration, enabling HomeAssistant users to remove all items from a to-do list, regardless of their status (completed or not). 

### Changes in code:
1. __init__.py
- Registered the remove_all_items service with async_register_entity_service.
- Implemented the _async_remove_all_items function to remove all items

2. const.py
- Added a constant to represent the new service
`REMOVE_ALL_ITEMS = "remove_all_items"`

3. icons.json
- Added an icon for the remove_all_items service:
`"remove_all_items": {
    "service": "mdi:clipboard-off"
}`

4. strings.json
- Updated service names and descriptions:
`"remove_all_items": {
    "name": "Remove all to-do list items",
    "description": "Remove all to-do list items, clearing the to-do list."
}`

5. Test Suite
- Added a test case for remove_all_items:
  - Verifies successful removal of all items from the list.
  - Ensures no errors occur when the service is called on an empty list. 

### Impact:
1. Simplifies the process of clearing to-do lists with the remove_all_items action.

2. No Breaking Changes:
- The existing functionality of other services (add_item, remove_completed_items, etc.) remains unchanged.

3. Maintenance:
- The additions align with the current structure for easy updates and extensibility.


### How to test:
Pre-check:
Add to-do list items in the Shopping list/or any to-do list in the sidebar

1. Go to Settings -> Automations & Scenes -> Scripts.
2. Click + Add Script
3. Under Sequence, click + Add Action.
4. Select Perform Action (Previously known as call service)
5. In Action field, choose todo.remove_all_items.
7. For Targets, click 'Choose entity', then select the to-do list entity you want to clear (e.g., todo.shopping_list).
8. Click Save Script
9. Give the script a name (e.g., "Clear All Tasks"). Click Rename.
10. In Scripts tab again, click the 3 vertical dots, then click "Run".