### PR TITLE
Performance Tasks Group Component

### DIFF
--- a/homeassistant/components/group/debounce.py
+++ b/homeassistant/components/group/debounce.py
@@ -1,0 +1,62 @@
+"""Provides a decorator for debouncing function calls."""
+
+import asyncio
+from collections.abc import Callable, Coroutine
+import contextlib
+from typing import Any, Protocol, cast
+
+
+class DebouncedCallable(Protocol):
+    """Protocol for a debounced callable with a close method."""
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> None:
+        """Call the debounced function."""
+
+    async def close(self) -> None:
+        """Close the debounced callable."""
+
+
+class Debounce:
+    """Debounce class to limit the frequency of a function call."""
+
+    def __init__(self, delay: float) -> None:
+        """Initialize the Debounce class with a delay."""
+        self._delay = delay
+        self._queue: asyncio.Queue[tuple[Any, Any]] = asyncio.Queue()
+        self._task: asyncio.Task[Any] | None = None
+        self._is_closing: bool = False
+
+    def __call__(
+        self, func: Callable[..., Coroutine[Any, Any, None]]
+    ) -> DebouncedCallable:
+        """Wrap the function with a debounced version."""
+
+        async def debounced_wrapper(*args: Any, **kwargs: Any) -> None:
+            """Debounce the wrapped callable."""
+            if self._is_closing:
+                return
+            await self._queue.put((args, kwargs))
+            if self._task is None or self._task.done():
+                self._task = asyncio.create_task(self._process_queue(func))
+
+        async def close() -> None:
+            """Expose a close method to stop the debounce."""
+            self._is_closing = True
+            if self._task:
+                self._task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._task
+
+        # Adding the close method to the debounced wrapper, then cast to meet the protocol
+        setattr(debounced_wrapper, "close", close)
+        return cast(DebouncedCallable, debounced_wrapper)  # Explicit cast
+
+    async def _process_queue(
+        self, func: Callable[..., Coroutine[Any, Any, None]]
+    ) -> None:
+        """Process the queue with a delay."""
+        while not self._queue.empty():
+            args, kwargs = await self._queue.get()
+            with contextlib.suppress(Exception):
+                await func(*args, **kwargs)
+            await asyncio.sleep(self._delay)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Key Changes Summary

1. entity.py
Change: Integration of the new Debounce class into entity updates or state-change methods.

Impact:

- Prevents rapid successive calls to state update methods, reducing unnecessary processing overhead.
- Ensures smoother handling of asynchronous updates without overwhelming the event loop.
- Potential delay in immediate updates, requiring careful testing for timing-sensitive logic.

2. debounce.py
Change: Added a Debounce class to manage queued and delayed asynchronous function calls.
Key Features:
Processes queued calls with a configurable delay.
Prevents overlapping or redundant calls during rapid state changes.
Introduced an optional flush() method to ensure tasks are processed immediately (useful for testing).

Impact:

- Improved efficiency in handling frequent updates.
- Reduces unintended behavior caused by multiple rapid calls.
- Adds slight complexity to testing due to delayed processing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
